### PR TITLE
Default log level to WARNING; convert prints to logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "s2aff"
-version = "0.202"
+version = "0.203"
 description = "Semantic Scholar's Affiliation Extraction: Link Your Raw Affiliations to ROR IDs"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -29,7 +29,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "pyarrow<21",
-  "s2aff_rust==0.202",
+  "s2aff_rust==0.203",
   "setuptools==71.1.0",
 ]
 

--- a/s2aff/__init__.py
+++ b/s2aff/__init__.py
@@ -6,11 +6,11 @@ from s2aff.model import parse_ner_prediction
 from s2aff.rust_backend import rust_available
 
 logger = logging.getLogger("s2aff")
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.WARNING)
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 ch = logging.StreamHandler()
 ch.setFormatter(formatter)
-ch.setLevel(logging.INFO)
+ch.setLevel(logging.WARNING)
 logger.addHandler(ch)
 
 
@@ -113,9 +113,9 @@ class S2AFF:
         if isinstance(raw_affiliations, str):
             raw_affiliations = [raw_affiliations]
 
-        print("Getting NER predictions in bulk...")
+        logger.debug("Getting NER predictions in bulk...")
         ner_predictions = self.ner_predictor.predict(raw_affiliations)
-        print("Done")
+        logger.debug("Done")
 
         batch_rerank = None
         if self.stage2_pipeline == "rust" and hasattr(
@@ -132,9 +132,11 @@ class S2AFF:
             batch_indices = []
 
             for counter, (raw_affiliation, ner_prediction) in enumerate(zip(raw_affiliations, ner_predictions)):
-                print(
-                    f"Getting ROR candidates and reranking for: '{raw_affiliation}' ({counter+1}/{len(raw_affiliations)})",
-                    end="\r",
+                logger.debug(
+                    "Getting ROR candidates and reranking for: '%s' (%d/%d)",
+                    raw_affiliation,
+                    counter + 1,
+                    len(raw_affiliations),
                 )
                 main, child, address, early_candidates = parse_ner_prediction(ner_prediction, self.ror_index)
                 # sometimes the affiliation strings just contain GRID, ISNI, or ROR ids directly
@@ -282,9 +284,11 @@ class S2AFF:
 
         outputs = []
         for counter, (raw_affiliation, ner_prediction) in enumerate(zip(raw_affiliations, ner_predictions)):
-            print(
-                f"Getting ROR candidates and reranking for: '{raw_affiliation}' ({counter+1}/{len(raw_affiliations)})",
-                end="\r",
+            logger.debug(
+                "Getting ROR candidates and reranking for: '%s' (%d/%d)",
+                raw_affiliation,
+                counter + 1,
+                len(raw_affiliations),
             )
             main, child, address, early_candidates = parse_ner_prediction(ner_prediction, self.ror_index)
             # sometimes the affiliation strings just contain GRID, ISNI, or ROR ids directly

--- a/s2aff/file_cache.py
+++ b/s2aff/file_cache.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import tempfile
@@ -9,6 +10,7 @@ from typing import Tuple, Union, IO
 from hashlib import sha256
 from s2aff.consts import CACHE_ROOT
 
+logger = logging.getLogger("s2aff")
 
 ARTIFACTS_CACHE = str(CACHE_ROOT / "artifacts")
 
@@ -119,7 +121,7 @@ def get_from_cache(url: str, cache_dir: str = None) -> str:
         # Download to temporary file, then copy to cache dir once finished.
         # Otherwise you get corrupt cache entries if the download gets interrupted.
         with tempfile.NamedTemporaryFile() as temp_file:  # type: IO
-            print(f"{url} not found in cache, downloading to {temp_file.name}")
+            logger.info("%s not found in cache, downloading to %s", url, temp_file.name)
 
             # GET file object
             http_get(url, temp_file)
@@ -129,7 +131,7 @@ def get_from_cache(url: str, cache_dir: str = None) -> str:
             # shutil.copyfileobj() starts at the current position, so go to the start
             temp_file.seek(0)
 
-            print(f"Finished download, copying {temp_file.name} to cache at {cache_path}")
+            logger.info("Finished download, copying %s to cache at %s", temp_file.name, cache_path)
             with open(cache_path, "wb") as cache_file:
                 shutil.copyfileobj(temp_file, cache_file)
 

--- a/s2aff/lightgbm_helpers.py
+++ b/s2aff/lightgbm_helpers.py
@@ -4,12 +4,15 @@ Created on Tue May 29 12:35:14 2018
 @author: serge
 """
 
+import logging
 import time
 from abc import ABCMeta, abstractmethod
 from itertools import groupby
 import numpy as np
 import lightgbm as lgb
 from hyperopt import hp, fmin, tpe, Trials, STATUS_OK, STATUS_FAIL
+
+logger = logging.getLogger("s2aff")
 
 
 def format_group(g):
@@ -53,15 +56,15 @@ class Experiment(object, metaclass=ABCMeta):
         cv_result.update({"hyperopt_eval_num": self.hyperopt_eval_num, "best_loss": self.best_loss})
 
         if verbose:
-            print(
-                "[{0}/{1}]\teval_time={2:.2f} sec\tcurrent_{3}={4:.6f}\tmin_{3}={5:.6f}".format(
-                    self.hyperopt_eval_num,
-                    self.hyperopt_evals,
-                    eval_time,
-                    self.eval_metric,
-                    cv_result["loss"],
-                    self.best_loss,
-                )
+            logger.debug(
+                "[%d/%d]\teval_time=%.2f sec\tcurrent_%s=%.6f\tmin_%s=%.6f",
+                self.hyperopt_eval_num,
+                self.hyperopt_evals,
+                eval_time,
+                self.eval_metric,
+                cv_result["loss"],
+                self.eval_metric,
+                self.best_loss,
             )
         return cv_result
 
@@ -99,25 +102,28 @@ class Experiment(object, metaclass=ABCMeta):
         group_test,
         weights_test,
     ):
-        print("Loading and preprocessing dataset...")
+        logger.info("Loading and preprocessing dataset...")
         train_dmatrix = self.convert_data(X_train, y_train, group_train, weights_train)
         val_dmatrix = self.convert_data(X_val, y_val, group_val, weights_val)
         test_dmatrix = self.convert_data(X_test, y_test, group_test, weights_test)
 
-        print("Optimizing params...")
+        logger.info("Optimizing params...")
         cv_result = self.optimize_params(train_dmatrix, val_dmatrix)
-        self.print_result(cv_result, "\nBest result on cv")
+        self.print_result(cv_result, "Best result on cv")
 
-        print("\nTraining algorithm with the tuned parameters for different seeds...")
+        logger.info("Training algorithm with the tuned parameters for different seeds...")
         test_losses = []
         for seed in [42, 1999, self.random_seed]:
             test_result = self.run_test(train_dmatrix, test_dmatrix, seed=seed)
             test_losses.append(test_result["loss"])
-            print("For seed=%d Test's %s : %.5f" % (seed, self.eval_metric, test_losses[-1]))
+            logger.debug("For seed=%d Test's %s : %.5f", seed, self.eval_metric, test_losses[-1])
 
-        print(
-            "\nTest's %s mean: %.5f, Test's %s std: %.5f"
-            % (self.eval_metric, np.mean(test_losses), self.eval_metric, np.std(test_losses))
+        logger.info(
+            "Test's %s mean: %.5f, Test's %s std: %.5f",
+            self.eval_metric,
+            np.mean(test_losses),
+            self.eval_metric,
+            np.std(test_losses),
         )
 
         return test_losses
@@ -141,17 +147,17 @@ class Experiment(object, metaclass=ABCMeta):
         return self.trials.best_trial["result"]
 
     def print_result(self, result, name="", extra_keys=None):
-        print("%s:\n" % name)
-        print("%s = %s" % (self.eval_metric, result["loss"]))
+        logger.info("%s:", name)
+        logger.info("%s = %s", self.eval_metric, result["loss"])
         if "best_n_estimators" in result.keys():
-            print("best_n_estimators = %s" % result["best_n_estimators"])
+            logger.info("best_n_estimators = %s", result["best_n_estimators"])
         elif "n_estimators" in result.keys():
-            print("n_estimators = %s" % result["n_estimators"])
-        print("params = %s" % result["params"])
+            logger.info("n_estimators = %s", result["n_estimators"])
+        logger.info("params = %s", result["params"])
         if extra_keys is not None:
             for k in extra_keys:
                 if k in result:
-                    print("%s = %f" % (k, result[k]))
+                    logger.info("%s = %f", k, result[k])
 
 
 class lightgbmExperiment(Experiment):

--- a/s2aff/ror.py
+++ b/s2aff/ror.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import math
 import re
 from collections import Counter, defaultdict
@@ -22,6 +23,8 @@ from s2aff.consts import (
 from s2aff.file_cache import cached_path
 from s2aff.model import parse_ner_prediction
 from s2aff.text import STOPWORDS, fix_text, INVERTED_ABBREVIATION_DICTIONARY, normalize_geoname_id
+
+logger = logging.getLogger("s2aff")
 
 ror_extractor = re.compile(r"(?:https?://)?ror\.org/(0[a-z0-9]{8})", re.I)
 grid_extractor = re.compile(r"(grid\.\d{4,6}\.[0-9a-f]{1,2})")
@@ -241,7 +244,7 @@ class RORIndex:
             for line in f:
                 line_json = json.loads(line)
                 if line_json["ror_id"] in self.ror_dict:
-                    print("Editing ROR database", line_json)
+                    logger.debug("Editing ROR database %s", line_json)
                     if line_json["action"] == "append":
                         if line_json["value"] not in self.ror_dict[line_json["ror_id"]][line_json["key"]]:
                             self.ror_dict[line_json["ror_id"]][line_json["key"]].append(line_json["value"])

--- a/s2aff_rust/pyproject.toml
+++ b/s2aff_rust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "s2aff_rust"
-version = "0.202"
+version = "0.203"
 requires-python = ">=3.8"
 
 [tool.maturin]


### PR DESCRIPTION
Sets the `s2aff` logger default level to WARNING and replaces `print()` calls across the package with level-appropriate `logger` calls.

## Why

The serving path (via FireLens) ships all stdout/stderr to Datadog. The per-affiliation `print(...)` in `S2AFF` (`__init__.py`) emitted one log line per affiliation (the `Getting ROR candidates and reranking for: ...` flood). At WARNING these are suppressed in prod, and everything now flows through the standard logger so levels can be tuned.

## Changes

- `__init__.py`: logger + handler default level `INFO` → `WARNING`.
- Prints → `logger` with lazy `%` args:
  - per-item / serving-path chatter (NER bulk, per-affiliation ROR reranking, ROR db edits) → `debug`
  - download start/finish (`file_cache.py`) and training milestones (`lightgbm_helpers.py`) → `info`; per-eval / per-seed detail → `debug`
- Added the shared `s2aff` logger to `file_cache.py`, `ror.py`, `lightgbm_helpers.py`.
- Version bump `0.202` → `0.203` (package + `s2aff_rust` pin + `s2aff_rust/pyproject.toml`).

## Not changed

- `rust_backend.py` `_rust_log`: already env-gated (`S2AFF_RUST_LOG`, off by default) and stderr-only.
- `api_server.py` FastAPI `version="0.2.0"`: decoupled from the package version.